### PR TITLE
Update to http4s-0.3.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,15 +6,13 @@ organization := "org.purang.net"
 
 scalaVersion := "2.10.4"
 
-val http4sVersion = "0.2.0"
+val http4sVersion = "0.3.0"
 
 libraryDependencies ++= Seq(
   "org.http4s" %% "http4s-core" % http4sVersion,
   "org.http4s" %% "http4s-dsl" % http4sVersion,
-  "org.http4s" %% "http4s-blaze" % http4sVersion,
-  "io.argonaut" %% "argonaut" % "6.0.4",
-  "org.scalaz" %% "scalaz-core" % "7.0.6"  withSources(),
-  "org.scalaz" %% "scalaz-concurrent" % "7.0.6"  withSources(),
+  "org.http4s" %% "http4s-blazeserver" % http4sVersion,
+  "io.argonaut" %% "argonaut" % "6.1-M4" changing(),
   "org.scalacheck" %% "scalacheck" % "1.11.4" % "test",
   "org.scalatest" %% "scalatest" % "2.1.6" % "test"
   )

--- a/src/main/scala/org/purang/net/httpize/Httpize.scala
+++ b/src/main/scala/org/purang/net/httpize/Httpize.scala
@@ -1,50 +1,38 @@
 package org.purang.net.httpize
 
-import org.http4s.blaze._
-import org.http4s.blaze.pipeline.LeafBuilder
-import org.http4s.blaze.websocket.WebSocketSupport
-import org.http4s.blaze.channel.nio2.NIO2ServerChannelFactory
-
-import java.net.InetSocketAddress
-import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledThreadPoolExecutor
 import com.typesafe.scalalogging.slf4j.StrictLogging
-import java.nio.channels.AsynchronousSocketChannel
 import org.http4s.server.HttpService
-import org.http4s.{Status, Request}
-import org.http4s.blaze.channel.SocketConnection
+import org.http4s.server.blaze.BlazeServer
+import org.http4s.Request
 import org.http4s.server.middleware.GZip
 
+import org.http4s.dsl._
 
-class Httpize(addr: InetSocketAddress) extends StrictLogging {
 
-  private val pool = Executors.newCachedThreadPool()
+class Httpize(host: String, port: Int) extends StrictLogging {
 
-  val routes = new Routes().service
+  private val pool = new ScheduledThreadPoolExecutor(3)
+
+  val routes = new Routes(pool).service
   val static = new StaticRoutes().service
   val gzipped = new GzipRoutes().service
 
   val service: HttpService =  { case req: Request =>
-    val uri = req.requestUri.path
+    val uri = req.uri.path
     if (uri.endsWith("html")) {
-      logger.info(s"${req.remoteAddr.getOrElse("null")} -> ${req.requestMethod}: ${req.requestUri.path}")
+      logger.info(s"${req.remoteAddr.getOrElse("null")} -> ${req.method}: ${req.uri.path}")
     }
 
-    routes orElse GZip(gzipped) orElse static applyOrElse (req, {_: Request => Status.NotFound(req)})
+    routes orElse GZip(gzipped) orElse static applyOrElse (req, {_: Request => NotFound(req.uri.path)})
   }
 
-  private val factory = new NIO2ServerChannelFactory(f) {
-    override protected def acceptConnection(channel: AsynchronousSocketChannel): Boolean = {
-      logger.info(s"New connection: ${channel.getRemoteAddress}")
-      super.acceptConnection(channel)
-    }
-  }
-
-  def f(conn: SocketConnection) = {
-    val s = new Http1Stage(service, Some(conn))(pool) with WebSocketSupport
-    LeafBuilder(s)
-  }
-
-  def run(): Unit = factory.bind(addr).run()
+  // Build the server instance and begin
+  def run(): Unit = BlazeServer.newBuilder
+    .withHost(host)
+    .withPort(port)
+    .mountService(service, "")
+    .run()
 }
 
 object Httpize extends StrictLogging {
@@ -57,6 +45,6 @@ object Httpize extends StrictLogging {
   logger.info(s"Starting Http4s-blaze example on '$ip:$port'")
   println(s"Starting Http4s-blaze example on '$ip:$port'")
 
-  def main(args: Array[String]): Unit = new Httpize(new InetSocketAddress(ip, port)).run()
+  def main(args: Array[String]): Unit = new Httpize(ip, port).run()
 }
 

--- a/src/main/scala/org/purang/net/httpize/ResourceCache.scala
+++ b/src/main/scala/org/purang/net/httpize/ResourceCache.scala
@@ -7,7 +7,8 @@ import org.http4s.Header.`Content-Type`
 import scalaz.stream.io.chunkR
 import com.typesafe.scalalogging.slf4j.StrictLogging
 
-import org.http4s.Http4s._
+import org.http4s.dsl._
+
 
 /**
  * Created by Bryce Anderson on 4/12/14.
@@ -32,6 +33,7 @@ class ResourceCache extends StrictLogging {
     } else Option(getClass.getResourceAsStream(sanitize(path)))
     rs.map { p =>
       val bytes = Process.constant(8*1024)
+        .toSource
         .through(chunkR(p))
         .runLog
         .run
@@ -62,8 +64,6 @@ class ResourceCache extends StrictLogging {
           .getOrElse(MediaType.`application/octet-stream`)
         else MediaType.`application/octet-stream`
       }
-
-
 
       Ok(bytes).putHeaders(`Content-Type`(mime))
     }

--- a/src/main/scala/org/purang/net/httpize/StaticRoutes.scala
+++ b/src/main/scala/org/purang/net/httpize/StaticRoutes.scala
@@ -1,6 +1,6 @@
 package org.purang.net.httpize
 
-import org.http4s.Http4s._
+import org.http4s.dsl._
 
 import com.typesafe.scalalogging.slf4j.LazyLogging
 import org.http4s.server.HttpService

--- a/src/main/scala/org/purang/net/httpize/package.scala
+++ b/src/main/scala/org/purang/net/httpize/package.scala
@@ -1,13 +1,10 @@
 package org.purang.net
 
-import org.http4s._
 import argonaut._, Argonaut._
-import org.http4s.Header.`Content-Type`
+import org.http4s._
 import scodec.bits.ByteVector
 
 import Header.`Content-Type`.`application/json`
-import org.http4s.Cookie
-import org.http4s.Status.EntityResponseGenerator
 import scalaz.concurrent.{Strategy, Task}
 import java.util.concurrent.ExecutorService
 
@@ -18,28 +15,10 @@ package object httpize {
       Function.unlift(pf.lift(_) flatMap that.lift)
   }
 
-  implicit def TWritable[T](implicit charset: CharacterSet = CharacterSet.`UTF-8`, encode: EncodeJson[T]) =
-    new SimpleWritable[T] {
-      def contentType: `Content-Type` = `application/json`.withCharset(charset)
-
-      def asChunk(t: T) = ByteVector.view(encode(t).nospaces.getBytes(charset.charset))
-    }
-
-  val Okk = new Status(200, "OK") with EntityResponseGenerator {
-    self: Status =>
-    def apply[A](body: A, contentType: `Content-Type`, mheaders: Headers = Headers.empty)(implicit w: Writable[A]): Task[Response] = {
-      var headers: Headers = Headers.empty
-      // tuple assignment runs afoul of https://issues.scala-lang.org/browse/SI-5301
-      headers :+= contentType
-      w.toBody(body).map { case (proc, len) =>
-        len foreach {
-          headers :+= Header.`Content-Length`(_)
-        }
-        Response(self, headers = headers ++ mheaders, body = proc)
-      }
-    }
+  implicit def TWritable[T](implicit charset: Charset = Charset.`UTF-8`, encode: EncodeJson[T]) = {
+    def go(t: T) = ByteVector.view(encode(t).nospaces.getBytes(charset.nioCharset))
+    Writable.simple(go, Headers(`application/json`.withCharset(charset)))
   }
-
 
   //IP address of remote client:
   case class IP(remote: String, `x-forwarded-for`: String)
@@ -83,8 +62,7 @@ package object httpize {
   case class All(method: Method, headers: HeadersContainer, origin: IP)
 
   object All {
-    def apply(r: Request): All = All(r.requestMethod, HeadersContainer(r.headers), IP(r))
-      Cookie
+    def apply(r: Request): All = All(r.method, HeadersContainer(r.headers), IP(r))
 
     implicit def AllCodecJson: EncodeJson[All] = jencode3L((a:All) => (a.method, a.headers, a.origin))("method", "headers", "origin")
 


### PR DESCRIPTION
This updates to the latest http4s release available in maven central.

**Changes**
- Simplified server initialization
- Writable instance needed reworking
- Use the version of scalaz dragged along by scalaz-stream (7.1 I believe)

Thanks again for the cool demo. Do you mind if we link to it from the [http4s.org](http://http4s.org) website?
